### PR TITLE
Polish off internal database types to match the specification

### DIFF
--- a/core/monitor/transaction_monitor.go
+++ b/core/monitor/transaction_monitor.go
@@ -82,11 +82,16 @@ func (tm *TransactionMonitor) createTransaction(hash common.Hash) (*types.Transa
 	if err != nil {
 		return nil, err
 	}
+	gasPrice, err := hexutil.DecodeUint64(txOrigin.GasPrice)
+	if err != nil {
+		return nil, err
+	}
 
 	tx := &types.Transaction{
 		Hash:              common.HexToHash(txOrigin.Hash),
 		Status:            txOrigin.Status == "0x1",
 		BlockNumber:       blockNumber,
+		BlockHash:         common.HexToHash(txOrigin.Block.Hash),
 		Index:             txOrigin.Index,
 		Nonce:             nonce,
 		From:              common.HexToAddress(txOrigin.From.Address),
@@ -94,6 +99,7 @@ func (tm *TransactionMonitor) createTransaction(hash common.Hash) (*types.Transa
 		Value:             value,
 		Gas:               gas,
 		GasUsed:           gasUsed,
+		GasPrice:          gasPrice,
 		CumulativeGasUsed: cumulativeGasUsed,
 		CreatedContract:   common.HexToAddress(txOrigin.CreatedContract.Address),
 		Data:              hexutil.MustDecode(txOrigin.InputData),

--- a/database/elasticsearch/README.md
+++ b/database/elasticsearch/README.md
@@ -82,22 +82,12 @@ Transaction {
     TransactionIndex
     Value
     IsPrivate
-    Receipt: {
-      ContractAddress
-      CumulativeGasUsed
-      GasUsed
-      Logs: [{
-          Address
-          Data,
-          LogIndex
-          Topics
-      }],
-      LogsBloom
-      Status
-      Root
-    }
-    
-    ContractsCalled
+    ContractAddress
+    CumulativeGasUsed
+    GasUsed
+    Status
+    Root
+    InternalCalls
 }
 ```
 

--- a/database/elasticsearch/elasticsearch_database_transactiondb_test.go
+++ b/database/elasticsearch/elasticsearch_database_transactiondb_test.go
@@ -59,15 +59,15 @@ func TestElasticsearchDB_WriteTransaction_WithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	updatedTestTx := testTransaction
-	updatedTestTx.InternalCalls = make([]*types.InternalCall, 0)
-
 	mockedClient := NewMockAPIClient(ctrl)
+
+	var convertedTx Transaction
+	convertedTx.From(&testTransaction)
 
 	req := esapi.IndexRequest{
 		Index:      TransactionIndex,
 		DocumentID: testTransaction.Hash.String(),
-		Body:       esutil.NewJSONReader(updatedTestTx),
+		Body:       esutil.NewJSONReader(convertedTx),
 		Refresh:    "true",
 	}
 
@@ -86,15 +86,15 @@ func TestElasticsearchDB_WriteTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	updatedTestTx := testTransaction
-	updatedTestTx.InternalCalls = make([]*types.InternalCall, 0)
+	var convertedTx Transaction
+	convertedTx.From(&testTransaction)
 
 	mockedClient := NewMockAPIClient(ctrl)
 
 	req := esapi.IndexRequest{
 		Index:      TransactionIndex,
 		DocumentID: testTransaction.Hash.String(),
-		Body:       esutil.NewJSONReader(updatedTestTx),
+		Body:       esutil.NewJSONReader(convertedTx),
 		Refresh:    "true",
 	}
 
@@ -111,9 +111,6 @@ func TestElasticsearchDB_WriteTransaction(t *testing.T) {
 func TestElasticsearchDB_ReadTransaction_WithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
-	updatedTestTx := testTransaction
-	updatedTestTx.InternalCalls = make([]*types.InternalCall, 0)
 
 	mockedClient := NewMockAPIClient(ctrl)
 
@@ -137,9 +134,6 @@ func TestElasticsearchDB_ReadTransaction_WithErrorUnmarshalling(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	updatedTestTx := testTransaction
-	updatedTestTx.InternalCalls = make([]*types.InternalCall, 0)
-
 	mockedClient := NewMockAPIClient(ctrl)
 
 	req := esapi.GetRequest{
@@ -162,9 +156,9 @@ func TestElasticsearchDB_ReadTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	updatedTestTx := testTransaction
-	updatedTestTx.InternalCalls = make([]*types.InternalCall, 0)
-	asJson, _ := json.Marshal(updatedTestTx)
+	var convertedTx Transaction
+	convertedTx.From(&testTransaction)
+	asJson, _ := json.Marshal(convertedTx)
 
 	mockedClient := NewMockAPIClient(ctrl)
 
@@ -183,5 +177,5 @@ func TestElasticsearchDB_ReadTransaction(t *testing.T) {
 	tx, err := db.ReadTransaction(testTransaction.Hash)
 
 	assert.Nil(t, err, "unexpected error")
-	assert.Equal(t, tx, &updatedTestTx, "unexpected transaction returned")
+	assert.Equal(t, tx, &testTransaction, "unexpected transaction returned")
 }

--- a/types/types.go
+++ b/types/types.go
@@ -23,12 +23,14 @@ type Transaction struct {
 	Hash              common.Hash     `json:"hash"`
 	Status            bool            `json:"status"`
 	BlockNumber       uint64          `json:"blockNumber"`
+	BlockHash         common.Hash     `json:"blockHash"`
 	Index             uint64          `json:"index"`
 	Nonce             uint64          `json:"nonce"`
 	From              common.Address  `json:"from"`
 	To                common.Address  `json:"to"`
 	Value             uint64          `json:"value"`
 	Gas               uint64          `json:"gas"`
+	GasPrice          uint64          `json:"gasPrice"`
 	GasUsed           uint64          `json:"gasUsed"`
 	CumulativeGasUsed uint64          `json:"cumulativeGasUsed"`
 	CreatedContract   common.Address  `json:"createdContract"`


### PR DESCRIPTION
Add conversion methods for each of the internal types to the application types.go
Polish off internal database types to match the specification.