### PR TITLE
Add configurable flush time & Remove ticker refresh

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -28,7 +28,3 @@ templates = [
     graphQLUrl = "http://localhost:8547/graphql"
     reconnectInterval = 5
     maxReconnectTries = 5
-
-[tuning]
-
-    blockProcessingQueueSize = 1000

--- a/core/monitor/batch_writer.go
+++ b/core/monitor/batch_writer.go
@@ -13,8 +13,6 @@ import (
 //TODO: Arbitrary for now, allow for updating based on seen blocks?
 const maxTransactionMultiplier = 10
 
-const timeoutPeriod = 2 * time.Second
-
 type BlockAndTransactions struct {
 	block *types.Block
 	txs   []*types.Transaction
@@ -23,6 +21,7 @@ type BlockAndTransactions struct {
 type BatchWriter struct {
 	maxBlocks       int
 	maxTransactions int
+	flushPeriod     int
 
 	currentWorkUnits        []*BlockAndTransactions
 	currentTransactionCount int
@@ -33,10 +32,11 @@ type BatchWriter struct {
 	stopFeed event.Feed
 }
 
-func NewBatchWriter(batchWorkChan chan *BlockAndTransactions, db database.Database) *BatchWriter {
+func NewBatchWriter(db database.Database, batchWorkChan chan *BlockAndTransactions, flushPeriod int) *BatchWriter {
 	bp := &BatchWriter{
 		maxBlocks:               cap(batchWorkChan),
 		maxTransactions:         maxTransactionMultiplier * cap(batchWorkChan),
+		flushPeriod:             flushPeriod,
 		currentWorkUnits:        make([]*BlockAndTransactions, 0, cap(batchWorkChan)),
 		currentTransactionCount: 0,
 		BatchWorkChan:           batchWorkChan,
@@ -46,7 +46,7 @@ func NewBatchWriter(batchWorkChan chan *BlockAndTransactions, db database.Databa
 }
 
 func (bw *BatchWriter) Run(stopChan <-chan types.StopEvent) {
-	ticker := time.NewTicker(timeoutPeriod)
+	ticker := time.NewTicker(time.Duration(bw.flushPeriod) * time.Second)
 	for {
 		select {
 		case newWorkUnit := <-bw.BatchWorkChan:
@@ -61,8 +61,6 @@ func (bw *BatchWriter) Run(stopChan <-chan types.StopEvent) {
 					<-ticker.C
 				}
 			}
-			ticker.Stop()
-			ticker = time.NewTicker(timeoutPeriod)
 		case <-ticker.C:
 			//if this fails, it will try again on the next run
 			if err := bw.BatchWrite(); err != nil {

--- a/core/monitor/service.go
+++ b/core/monitor/service.go
@@ -30,7 +30,7 @@ func NewMonitorService(db database.Database, quorumClient client.Client, consens
 		db:           db,
 		quorumClient: quorumClient,
 		blockMonitor: NewBlockMonitor(db, quorumClient, consensus, batchWriteChan),
-		batchWriter:  NewBatchWriter(batchWriteChan, db),
+		batchWriter:  NewBatchWriter(db, batchWriteChan, tuningConfig.BlockProcessingFlushPeriod),
 		totalWorkers: 3 * uint64(runtime.NumCPU()),
 	}
 }

--- a/types/config.go
+++ b/types/config.go
@@ -25,7 +25,8 @@ type DatabaseConfig struct {
 }
 
 type TuningConfig struct {
-	BlockProcessingQueueSize int `toml:"blockProcessingQueueSize"`
+	BlockProcessingQueueSize   int `toml:"blockProcessingQueueSize"`
+	BlockProcessingFlushPeriod int `toml:"blockProcessingFlushPeriod"`
 }
 
 type AddressConfig struct {
@@ -62,6 +63,9 @@ type ReportingConfig struct {
 func (rc *ReportingConfig) SetDefaults() {
 	if rc.Tuning.BlockProcessingQueueSize < 1 {
 		rc.Tuning.BlockProcessingQueueSize = 100
+	}
+	if rc.Tuning.BlockProcessingFlushPeriod < 1 {
+		rc.Tuning.BlockProcessingFlushPeriod = 3
 	}
 	if rc.Database != nil && rc.Database.CacheSize < 1 {
 		rc.Database.CacheSize = 10


### PR DESCRIPTION
Remove ticker refresh in the work unit processing. This is because if we have new work coming at low speed for example every second. With default 100 blockProcessingQueueSize, it means no data is written into DB within ~100 seconds period. We should make sure batch writer runs within a minimum configurable flush period.