### PR TITLE
Store storage entries and k/v pairs in a list

### DIFF
--- a/database/elasticsearch/elasticsearch_database.go
+++ b/database/elasticsearch/elasticsearch_database.go
@@ -454,9 +454,9 @@ func (es *ElasticsearchDB) IndexStorage(rawStorage map[types.Address]*types.Acco
 			BlockNumber: blockNumber,
 			StorageRoot: dumpAccount.Root,
 		}
-		converted := make(map[string]string)
+		converted := make([]StorageEntry, 0, len(dumpAccount.Storage))
 		for slot, val := range dumpAccount.Storage {
-			converted[slot.String()] = val
+			converted = append(converted, StorageEntry{slot, val})
 		}
 		storageMap := Storage{
 			StorageRoot: dumpAccount.Root,
@@ -669,8 +669,8 @@ func (es *ElasticsearchDB) GetStorage(address types.Address, blockNumber uint64)
 		return nil, err
 	}
 	converted := make(map[types.Hash]string)
-	for slot, val := range storageResult.Source.StorageMap {
-		converted[types.NewHash(slot)] = val
+	for _, storageEntry := range storageResult.Source.StorageMap {
+		converted[storageEntry.Key] = storageEntry.Value
 	}
 	return converted, nil
 }

--- a/database/elasticsearch/types.go
+++ b/database/elasticsearch/types.go
@@ -24,8 +24,13 @@ type State struct {
 }
 
 type Storage struct {
-	StorageRoot types.Hash        `json:"storageRoot"`
-	StorageMap  map[string]string `json:"storageMap"`
+	StorageRoot types.Hash     `json:"storageRoot"`
+	StorageMap  []StorageEntry `json:"storageMap"`
+}
+
+type StorageEntry struct {
+	Key   types.Hash
+	Value string
 }
 
 //


### PR DESCRIPTION
ElasticSearch has a (default) limit on the number of properties a document can have as 1000. A storage entry may go well beyond that, so instead they can be stored as k/v pairs, so that the number of properties is fixed at 2.

This only applies to ElasticSearch. The rest of the application will see the full map as before.