### PR TITLE
Use workers for storage filtering concurrency

### DIFF
--- a/core/filter/storage_filter.go
+++ b/core/filter/storage_filter.go
@@ -1,7 +1,9 @@
 package filter
 
 import (
+	"runtime"
 	"sync"
+	"time"
 
 	"quorumengineering/quorum-report/client"
 	"quorumengineering/quorum-report/log"
@@ -11,36 +13,158 @@ import (
 type StorageFilter struct {
 	db           FilterServiceDB
 	quorumClient client.Client
+
+	outstandingBlocks sync.WaitGroup
+	maxEntriesToSave  int
+
+	incomingBlockChan chan AccountStateWithBlock
+	pulledStateChan   chan AccountStateWithBlock
+
+	shutdownWg      sync.WaitGroup
+	shutdownChannel chan struct{}
+}
+
+type AccountStateWithBlock struct {
+	BlockNumber  uint64
+	AccountState map[types.Address]*types.AccountState
+	Addresses    []types.Address
 }
 
 func NewStorageFilter(db FilterServiceDB, quorumClient client.Client) *StorageFilter {
-	return &StorageFilter{db, quorumClient}
+	sf := &StorageFilter{
+		db:                db,
+		quorumClient:      quorumClient,
+		maxEntriesToSave:  100,
+		incomingBlockChan: make(chan AccountStateWithBlock),
+		pulledStateChan:   make(chan AccountStateWithBlock, 1000),
+
+		shutdownChannel: make(chan struct{}),
+	}
+
+	log.Info("Starting storage filter state fetch workers", "number", runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		sf.shutdownWg.Add(1)
+		sf.StateFetchWorker()
+	}
+	log.Info("Started storage filter state fetch workers")
+	log.Info("Starting storage filter state saving workers", "number", runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		sf.shutdownWg.Add(1)
+		sf.StateSavingWorker()
+	}
+	log.Info("Started storage filter state saving workers")
+
+	return sf
 }
 
 func (sf *StorageFilter) IndexStorage(addresses []types.Address, startBlockNumber, endBlockNumber uint64) error {
-	var (
-		wg        sync.WaitGroup
-		returnErr error
-	)
+	log.Info("Indexing storage", "start", startBlockNumber, "end", endBlockNumber)
 	for i := startBlockNumber; i <= endBlockNumber; i++ {
-		wg.Add(1)
-		go func(blockNumber uint64) {
-			defer wg.Done()
-			rawStorage := make(map[types.Address]*types.AccountState)
-			for _, address := range addresses {
-				log.Info("Pulling (indexing) contract storage", "address", address.String(), "block number", blockNumber)
-				dumpAccount, err := client.DumpAddress(sf.quorumClient, address, blockNumber)
-				rawStorage[address] = dumpAccount
-				if err != nil {
-					returnErr = err
-					return
+		sf.outstandingBlocks.Add(1)
+		emptyStorage := AccountStateWithBlock{
+			BlockNumber:  i,
+			AccountState: make(map[types.Address]*types.AccountState),
+			Addresses:    addresses,
+		}
+		sf.incomingBlockChan <- emptyStorage
+	}
+
+	sf.outstandingBlocks.Wait()
+	log.Info("Indexing storage complete", "start", startBlockNumber, "end", endBlockNumber)
+	return nil
+}
+
+func (sf *StorageFilter) StateFetchWorker() {
+	go func() {
+		defer sf.shutdownWg.Done()
+		for {
+			select {
+			case <-sf.shutdownChannel:
+				log.Debug("Shutdown request received", "loc", "storage filter - state fetch worker")
+				return
+			case blockToPull := <-sf.incomingBlockChan:
+				log.Info("Fetching contract storage", "block number", blockToPull.BlockNumber)
+				for _, address := range blockToPull.Addresses {
+					log.Debug("Fetching contract storage", "address", address.String(), "block number", blockToPull.BlockNumber)
+					dumpAccount, err := client.DumpAddress(sf.quorumClient, address, blockToPull.BlockNumber)
+					for err != nil {
+						log.Error("Unable to fetch contract state", "address", address.String(), "block number", blockToPull.BlockNumber, "err", err)
+						time.Sleep(time.Second) //TODO: make adaptive or block until websocket available
+						dumpAccount, err = client.DumpAddress(sf.quorumClient, address, blockToPull.BlockNumber)
+					}
+					blockToPull.AccountState[address] = dumpAccount
+				}
+				sf.pulledStateChan <- blockToPull
+			}
+		}
+	}()
+}
+
+func (sf *StorageFilter) StateSavingWorker() {
+	go func() {
+		defer sf.shutdownWg.Done()
+		for {
+			storage := make([]AccountStateWithBlock, 0)
+
+			select {
+			case st := <-sf.pulledStateChan:
+				storage = append(storage, st)
+			case <-sf.shutdownChannel:
+				log.Debug("Shutdown request received", "loc", "storage filter - state save worker")
+				return
+			}
+
+			for {
+				if len(storage) == sf.maxEntriesToSave {
+					break
+				}
+
+				isEmpty := false
+				select {
+				case st := <-sf.pulledStateChan:
+					storage = append(storage, st)
+				default:
+					isEmpty = true
+				}
+				if isEmpty {
+					break
 				}
 			}
-			if err := sf.db.IndexStorage(rawStorage, blockNumber); err != nil {
-				returnErr = err
-			}
-		}(i)
+
+			log.Debug("Saving storage entries", "number of entries", len(storage))
+
+			sf.SaveStorage(storage)
+		}
+	}()
+}
+
+func (sf *StorageFilter) SaveStorage(storage []AccountStateWithBlock) {
+	var thisRunWg sync.WaitGroup
+	thisRunWg.Add(len(storage))
+
+	saveSingle := func(storageData AccountStateWithBlock) {
+		defer thisRunWg.Done()
+
+		log.Info("Persisting storage", "blockNum", storageData.BlockNumber)
+		err := sf.db.IndexStorage(storageData.AccountState, storageData.BlockNumber)
+		//TODO: use error channel for returning error instead of looping
+		for err != nil {
+			err = sf.db.IndexStorage(storageData.AccountState, storageData.BlockNumber)
+		}
+		sf.outstandingBlocks.Done()
 	}
-	wg.Wait()
-	return returnErr
+
+	for _, storageData := range storage {
+		//TODO: change storage indexing to accept all data at once to remove goroutine call
+		go saveSingle(storageData)
+	}
+
+	thisRunWg.Wait()
+}
+
+func (sf *StorageFilter) Stop() {
+	log.Info("Stopping down storage filter")
+	sf.outstandingBlocks.Wait()
+	close(sf.shutdownChannel)
+	log.Info("Finished stopping storage filter")
 }


### PR DESCRIPTION
The storage filter fires off all storage requests at the same time, which can quickly overload both the reporting process and the attached Quorum process, resulting in a lot of memory usage and request timeouts.

To reduce the concurrency strain, this PR introduces workers for pulling storage and saving the storage. A pre-set number of workers will fetch the storage from Quorum and then pass it onto a preset number of workers who will save that state in the database.