### PR TITLE
Check contract template for ERC match on transfers

### DIFF
--- a/core/filter/service_test.go
+++ b/core/filter/service_test.go
@@ -98,6 +98,10 @@ func (f *FakeDB) RecordERC721Token(contract types.Address, holder types.Address,
 	return errors.New("not implemented")
 }
 
+func (f *FakeDB) GetContractABI(types.Address) (string, error) {
+	return "{}", nil
+}
+
 func (f *FakeDB) SetContractCreationTransaction(creationTxns map[types.Hash][]types.Address) error {
 	return nil
 }

--- a/core/filter/token/erc721_processor_test.go
+++ b/core/filter/token/erc721_processor_test.go
@@ -10,16 +10,17 @@ import (
 	"quorumengineering/quorum-report/types"
 )
 
-func TestERC721Processor_ProcessBlock_TxReadFail(t *testing.T) {
-	blk := &types.Block{
-		Hash:         types.NewHash("0xf4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"),
-		Transactions: []types.Hash{"efe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36"},
-	}
+var testErc721TokenBlock = &types.Block{
+	Number:       1,
+	Hash:         types.NewHash("0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8"),
+	Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
+}
 
+func TestERC721Processor_ProcessBlock_TxReadFail(t *testing.T) {
 	db := NewFakeTestTokenDatabase(errors.New("test tx read fail"), []*types.Transaction{})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{}, testErc721TokenBlock)
 
 	assert.EqualError(t, err, "test tx read fail")
 }
@@ -30,15 +31,11 @@ func TestERC721Processor_ProcessTransaction_NoEventsDoesNothing(t *testing.T) {
 		Hash:   types.NewHash("0xf4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"),
 		Events: []*types.Event{},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{tokenAddress}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc721AbiString}, testErc721TokenBlock)
 
 	assert.Nil(t, err)
 	assert.Len(t, db.RecordedContract, 0)
@@ -56,15 +53,11 @@ func TestERC721Processor_ProcessTransaction_NoErc721Events(t *testing.T) {
 			},
 		},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{tokenAddress}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc721AbiString}, testErc721TokenBlock)
 
 	assert.Nil(t, err)
 	assert.Len(t, db.RecordedContract, 0)
@@ -87,15 +80,11 @@ func TestERC721Processor_ProcessTransaction_Erc721EventForNonTrackedAddress(t *t
 			},
 		},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{tokenAddress}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc721AbiString}, testErc721TokenBlock)
 
 	assert.Nil(t, err)
 	assert.Len(t, db.RecordedContract, 0)
@@ -119,15 +108,11 @@ func TestERC721Processor_ProcessTransaction_SingleErc721Event(t *testing.T) {
 			},
 		},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{tokenAddress}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc721AbiString}, testErc721TokenBlock)
 
 	assert.Nil(t, err)
 	assert.Contains(t, db.RecordedContract, types.NewAddress("1932c48b2bf8102ba33b4a6b545c32236e342f34"))
@@ -136,6 +121,37 @@ func TestERC721Processor_ProcessTransaction_SingleErc721Event(t *testing.T) {
 	assert.EqualValues(t, 1, db.RecordedBlock)
 	assert.Len(t, db.RecordedToken, 1)
 	assert.EqualValues(t, db.RecordedToken[0], big.NewInt(1))
+}
+
+func TestERC721Processor_ProcessTransaction_SingleErc721EventForNonErc721Contract(t *testing.T) {
+	tokenAddress := types.NewAddress("0x1932c48b2bf8102ba33b4a6b545c32236e342f34")
+	tx := &types.Transaction{
+		Hash:        types.NewHash("0xf4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"),
+		BlockNumber: 1,
+		Events: []*types.Event{
+			{
+				Data:    types.NewHexData("0x00000000000000000000000000000000000000000000000000000000000003e8"),
+				Address: types.NewAddress("0x1932c48b2bf8102ba33b4a6b545c32236e342f34"),
+				Topics: []types.Hash{
+					"ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+					"000000000000000000000000ed9d02e382b34818e88b88a309c7fe71e65f419d",
+					"0000000000000000000000001349f3e1b8d71effb47b840594ff27da7e603d17",
+					"0000000000000000000000000000000000000000000000000000000000000001",
+				},
+			},
+		},
+	}
+
+	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
+	processor := NewERC721Processor(db)
+
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc20AbiString}, testErc721TokenBlock)
+
+	assert.Nil(t, err)
+	assert.Len(t, db.RecordedContract, 0)
+	assert.Len(t, db.RecordedHolder, 0)
+	assert.EqualValues(t, 0, db.RecordedBlock)
+	assert.Len(t, db.RecordedToken, 0)
 }
 
 func TestERC721Processor_ProcessTransaction_SingleErc721Event_WithDatabaseError(t *testing.T) {
@@ -156,15 +172,11 @@ func TestERC721Processor_ProcessTransaction_SingleErc721Event_WithDatabaseError(
 			},
 		},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(errors.New("test error - database"), []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{tokenAddress}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{tokenAddress: erc721AbiString}, testErc721TokenBlock)
 
 	assert.EqualError(t, err, "test error - database")
 	assert.Len(t, db.RecordedContract, 0)
@@ -196,18 +208,14 @@ func TestERC721Processor_ProcessTransaction_MultipleErc721Events(t *testing.T) {
 			},
 		},
 	}
-	blk := &types.Block{
-		Number:       1,
-		Transactions: []types.Hash{"f4f803b8d6c6b38e0b15d6cfe80fd1dcea4270ad24e93385fca36512bb9c2c59"},
-	}
 
 	db := NewFakeTestTokenDatabase(nil, []*types.Transaction{tx})
 	processor := NewERC721Processor(db)
 
-	err := processor.ProcessBlock([]types.Address{
-		types.NewAddress("0x1932c48b2bf8102ba33b4a6b545c32236e342f34"),
-		types.NewAddress("0x02826f2bce5596f49ef29f11de3dce29d6653f8c"),
-	}, blk)
+	err := processor.ProcessBlock(map[types.Address]string{
+		types.NewAddress("0x1932c48b2bf8102ba33b4a6b545c32236e342f34"): erc721AbiString,
+		types.NewAddress("0x02826f2bce5596f49ef29f11de3dce29d6653f8c"): erc721AbiString,
+	}, testErc721TokenBlock)
 
 	assert.Nil(t, err)
 	assert.Contains(t, db.RecordedContract, types.NewAddress("1932c48b2bf8102ba33b4a6b545c32236e342f34"))


### PR DESCRIPTION
Before registering a transfer of tokens for both ERC20 and ERC721, check the ABI attached to the contract actually implements ERC20/ERC721.

This stops false positives where a contract may have implemented the `Transfer` event but not the other portions of the token specification.

It will mean that transfers may be missed in the case where, for a portion of indexing, the attached template didn't conform to the ERC spec. This can be fixed by re-registering the contract with the correct template.