### PR TITLE
Merge the state and storage indices together

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -144,3 +144,12 @@ func CallBalanceOfERC20(c Client, contract types.Address, holder types.Address, 
 	err := c.RPCCall(&res, "eth_call", msg, blockAsHex)
 	return res, err
 }
+
+func StorageRoot(c Client, account types.Address, blockNum uint64) (types.Hash, error) {
+	var res types.Hash
+	err := c.RPCCall(&res, "eth_storageRoot", account.String(), fmt.Sprintf("0x%x", blockNum))
+	if err != nil && err.Error() == "can't find state object" {
+		return types.NewHash(""), nil
+	}
+	return res, err
+}

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -318,3 +318,24 @@ func TestCallBalanceOfERC20(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, types.HexData("12345"), contractCallResult)
 }
+
+func TestStorageRoot_WithError(t *testing.T) {
+	stubClient := NewStubQuorumClient(nil, nil)
+
+	result, err := StorageRoot(stubClient, types.NewAddress(""), 1)
+	assert.EqualError(t, err, "not found")
+	assert.EqualValues(t, "", result)
+}
+
+func TestStorageRoot(t *testing.T) {
+	mockRPC := map[string]interface{}{
+		"eth_storageRoot0x00000000000000000000000000000000000000000x1": types.NewHash("1"),
+	}
+
+	stubClient := NewStubQuorumClient(nil, mockRPC)
+
+	result, err := StorageRoot(stubClient, types.NewAddress(""), 1)
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, "0000000000000000000000000000000000000000000000000000000000000001", result)
+}

--- a/core/filter/service_test.go
+++ b/core/filter/service_test.go
@@ -14,10 +14,12 @@ import (
 func TestIndexBlock(t *testing.T) {
 	// setup
 	mockRPC := map[string]interface{}{
-		"debug_dumpAddress0x00000000000000000000000000000000000000010x4": &types.RawAccountState{},
-		"debug_dumpAddress0x00000000000000000000000000000000000000010x5": &types.RawAccountState{},
-		"debug_dumpAddress0x00000000000000000000000000000000000000010x6": &types.RawAccountState{},
-		"debug_dumpAddress0x00000000000000000000000000000000000000020x6": &types.RawAccountState{},
+		"eth_storageRoot0x00000000000000000000000000000000000000010x3": types.NewHash("1"),
+		"eth_storageRoot0x00000000000000000000000000000000000000010x4": types.NewHash("1"),
+		"eth_storageRoot0x00000000000000000000000000000000000000010x5": types.NewHash("1"),
+		"eth_storageRoot0x00000000000000000000000000000000000000010x6": types.NewHash("1"),
+		"eth_storageRoot0x00000000000000000000000000000000000000020x5": types.NewHash("1"),
+		"eth_storageRoot0x00000000000000000000000000000000000000020x6": types.NewHash("1"),
 	}
 	db := &FakeDB{
 		[]types.Address{types.NewAddress("1"), types.NewAddress("2")},

--- a/core/rpc/apis.go
+++ b/core/rpc/apis.go
@@ -194,7 +194,7 @@ func (r *RPCAPIs) GetAllEventsFromAddress(req *http.Request, args *AddressWithOp
 	return nil
 }
 
-func (r *RPCAPIs) GetStorage(req *http.Request, args *AddressWithOptionalBlock, reply *map[types.Hash]string) error {
+func (r *RPCAPIs) GetStorage(req *http.Request, args *AddressWithOptionalBlock, reply *types.StorageResult) error {
 	if args.Address == nil {
 		return ErrNoAddress
 	}
@@ -212,7 +212,7 @@ func (r *RPCAPIs) GetStorage(req *http.Request, args *AddressWithOptionalBlock, 
 	if err != nil {
 		return err
 	}
-	*reply = result
+	*reply = *result
 	return nil
 }
 

--- a/database/elasticsearch/constants.go
+++ b/database/elasticsearch/constants.go
@@ -9,7 +9,6 @@ const (
 	TemplateIndex    = "template"
 	BlockIndex       = "block"
 	StorageIndex     = "storage"
-	StateIndex       = "state"
 	TransactionIndex = "transaction"
 	EventIndex       = "event"
 	ERC20TokenIndex  = "erc20token"
@@ -17,7 +16,7 @@ const (
 )
 
 var (
-	AllIndexes = []string{MetaIndex, ContractIndex, TemplateIndex, BlockIndex, StorageIndex, StateIndex, TransactionIndex, EventIndex, ERC20TokenIndex, ERC721TokenIndex}
+	AllIndexes = []string{MetaIndex, ContractIndex, TemplateIndex, BlockIndex, StorageIndex, TransactionIndex, EventIndex, ERC20TokenIndex, ERC721TokenIndex}
 	// errors
 	ErrCouldNotResolveResp     = errors.New("could not resolve response body")
 	ErrIndexNotFound           = errors.New("index not found")

--- a/database/elasticsearch/query_templates.go
+++ b/database/elasticsearch/query_templates.go
@@ -65,7 +65,7 @@ func QueryByAddressWithBlockRangeOptionsTemplate(opt *types.PageOptions) string 
 	"query": {
 		"bool": {
 			"must": [
-				{ "match": { "address": "%s" } },
+				{ "match": { "contract": "%s" } },
 ` + createRangeQuery("blockNumber", opt.BeginBlockNumber, opt.EndBlockNumber) + `
 			]
 		}
@@ -73,6 +73,27 @@ func QueryByAddressWithBlockRangeOptionsTemplate(opt *types.PageOptions) string 
 }
 `
 }
+
+const QueryMatchContract = `
+{
+	"query": {
+		"bool": {
+			"must": [
+				{ "match": { "contract": "%s" } },
+				{ "range": { "blockNumber": { "lte": %d } } }
+			]
+		}
+	},
+	"sort": [
+		{
+			"blockNumber": {
+				"order": "desc",
+				"unmapped_type": "long"
+			}
+		}
+	]
+}
+`
 
 func QueryInternalTransactionsWithOptionsTemplate(options *types.QueryOptions) string {
 	return `

--- a/database/elasticsearch/types.go
+++ b/database/elasticsearch/types.go
@@ -17,13 +17,9 @@ type Template struct {
 	StorageABI   string `json:"storageAbi"`
 }
 
-type State struct {
-	Address     types.Address `json:"address"`
-	BlockNumber uint64        `json:"blockNumber"`
-	StorageRoot types.Hash    `json:"storageRoot"`
-}
-
 type Storage struct {
+	Contract    types.Address  `json:"contract"`
+	BlockNumber uint64         `json:"blockNumber"`
 	StorageRoot types.Hash     `json:"storageRoot"`
 	StorageMap  []StorageEntry `json:"storageMap"`
 }
@@ -72,10 +68,6 @@ type BlockQueryResult struct {
 
 type TokenHolderQueryResult struct {
 	Source ERC20TokenHolder `json:"_source"`
-}
-
-type StateQueryResult struct {
-	Source State `json:"_source"`
 }
 
 type StorageQueryResult struct {

--- a/database/factory/database_with_cache.go
+++ b/database/factory/database_with_cache.go
@@ -239,7 +239,7 @@ func (cachingDB *DatabaseWithCache) GetEventsFromAddressTotal(address types.Addr
 	return cachingDB.db.GetEventsFromAddressTotal(address, options)
 }
 
-func (cachingDB *DatabaseWithCache) GetStorage(address types.Address, blockNumber uint64) (map[types.Hash]string, error) {
+func (cachingDB *DatabaseWithCache) GetStorage(address types.Address, blockNumber uint64) (*types.StorageResult, error) {
 	return cachingDB.db.GetStorage(address, blockNumber)
 }
 

--- a/database/interface.go
+++ b/database/interface.go
@@ -65,7 +65,7 @@ type IndexDB interface {
 	GetTransactionsInternalToAddressTotal(types.Address, *types.QueryOptions) (uint64, error)
 	GetAllEventsFromAddress(types.Address, *types.QueryOptions) ([]*types.Event, error)
 	GetEventsFromAddressTotal(types.Address, *types.QueryOptions) (uint64, error)
-	GetStorage(types.Address, uint64) (map[types.Hash]string, error)
+	GetStorage(types.Address, uint64) (*types.StorageResult, error)
 	GetStorageWithOptions(types.Address, *types.PageOptions) ([]*types.StorageResult, error)
 	GetStorageTotal(types.Address, *types.PageOptions) (uint64, error)
 	GetLastFiltered(types.Address) (uint64, error)

--- a/database/memory/memory_database_test.go
+++ b/database/memory/memory_database_test.go
@@ -342,12 +342,14 @@ func testGetAllEventsByAddress(t *testing.T, db database.Database, address types
 
 func testGetStorage(t *testing.T, db database.Database, address types.Address, blockNumber uint64, expected int) {
 	storage, err := db.GetStorage(address, blockNumber)
-	if err != nil {
-		t.Fatalf("expected no error, but got %v", err)
-	}
-	if len(storage) != expected {
-		t.Fatalf("expected %v, but got %v", expected, len(storage))
-	}
+	assert.Nil(t, err)
+	assert.Len(t, storage.Storage, expected)
+
+	//test on a block number we don't have storage for
+	storageUnknown, err := db.GetStorage(address, blockNumber+1)
+	assert.Nil(t, err)
+	assert.Len(t, storageUnknown.Storage, 0)
+	assert.EqualValues(t, types.NewHash(""), storageUnknown.StorageRoot)
 }
 
 func TestMemoryDB_ContractCreationTransactions(t *testing.T) {

--- a/types/storage_types.go
+++ b/types/storage_types.go
@@ -124,5 +124,6 @@ type ParsedState struct {
 
 type StorageResult struct {
 	Storage     map[Hash]string
+	StorageRoot Hash
 	BlockNumber uint64
 }


### PR DESCRIPTION
Managing state and storage separately was intended to be a storage saving cost, but had the downside that it meant managing links between data.

The state and storage have been merged under the `Storage` index, with some notable changes:
- there is no sharing of storage between contracts. If multiple contracts have the same storage, they will each have their own entries with the storage duplicated.
- there is no sharing of storage between different blocks on the same contract. If a contract has State A, then changes to State B, then back to State A, it will have 3 storage entries.
- Storage entries are not continuous in block number. An omitted entry simple means that the storage did not change, so the latest entry at or before the query point should be considered the storage at that point in time.

The first two points will greatly increase the amount of storage needed compared to before, especially for large contracts, but the likelihood of making use of the space saving mechanism was small and deemed not worth it. Additionally, point three is meant to address the majority of the duplication.