### PR TITLE
Use concrete type to unmarshall to when tracing transactions

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -42,18 +42,18 @@ func fmtBlockNum(blockNumber uint64) string {
 	return fmt.Sprintf("0x%x", blockNumber)
 }
 
-func TraceTransaction(c Client, txHash types.Hash) (map[string]interface{}, error) {
+func TraceTransaction(c Client, txHash types.Hash) (types.RawOuterCall, error) {
 	log.Debug("Tracing transaction", "tx", txHash.String())
 
 	// Trace internal calls of the transaction
 	// Reference: https://github.com/ethereum/go-ethereum/issues/3128
-	var resp map[string]interface{}
+	var resp types.RawOuterCall
 	type TraceConfig struct {
 		Tracer string
 	}
 	err := c.RPCCall(&resp, traceTransaction, txHash.String(), &TraceConfig{Tracer: "callTracer"})
 	if err != nil {
-		return nil, err
+		return types.RawOuterCall{}, err
 	}
 	return resp, nil
 }

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -59,21 +59,20 @@ func TestTraceTransaction_WithError(t *testing.T) {
 
 	trace, err := TraceTransaction(stubClient, types.NewHash("0x0000000000000000000000000000000000000000000000000000000000000000"))
 	assert.EqualError(t, err, "not found")
-	assert.Nil(t, trace)
+	assert.Equal(t, trace, types.RawOuterCall{})
 }
 
 func TestTraceTransaction(t *testing.T) {
-	res := map[string]interface{}{
-		"customField": "value",
-	}
 	mockRPC := map[string]interface{}{
-		"debug_traceTransaction0x0000000000000000000000000000000000000000000000000000000000000000<*client.TraceConfig Value>": res,
+		"debug_traceTransaction0x0000000000000000000000000000000000000000000000000000000000000000<*client.TraceConfig Value>": types.RawOuterCall{
+			Calls: []types.RawInnerCall{{}},
+		},
 	}
 	stubClient := NewStubQuorumClient(nil, mockRPC)
 
 	trace, err := TraceTransaction(stubClient, types.NewHash("0x0000000000000000000000000000000000000000000000000000000000000000"))
 	assert.Nil(t, err)
-	assert.Equal(t, res, trace)
+	assert.Len(t, trace.Calls, 1)
 }
 
 func TestDumpAddress_WithError(t *testing.T) {

--- a/core/monitor/transaction.go
+++ b/core/monitor/transaction.go
@@ -1,8 +1,6 @@
 package monitor
 
 import (
-	"strconv"
-
 	"quorumengineering/quorum-report/client"
 	"quorumengineering/quorum-report/log"
 	"quorumengineering/quorum-report/types"
@@ -65,9 +63,10 @@ func (tm *DefaultTransactionMonitor) fetchTransaction(block *types.Block, hash t
 		IsPrivate:         txOrigin.IsPrivate,
 		Timestamp:         block.Timestamp,
 	}
-	events := []*types.Event{}
-	for _, l := range txOrigin.Logs {
-		e := &types.Event{
+
+	tx.Events = make([]*types.Event, len(txOrigin.Logs))
+	for i, l := range txOrigin.Logs {
+		tx.Events[i] = &types.Event{
 			Index:            l.Index,
 			Address:          l.Account.Address,
 			Topics:           l.Topics,
@@ -78,45 +77,24 @@ func (tm *DefaultTransactionMonitor) fetchTransaction(block *types.Block, hash t
 			TransactionIndex: txOrigin.Index,
 			Timestamp:        block.Timestamp,
 		}
-		events = append(events, e)
 	}
-	tx.Events = events
 
-	var traceResp map[string]interface{}
-	traceResp, err = client.TraceTransaction(tm.quorumClient, types.NewHash(tx.Hash.Hex()))
+	traceResp, err := client.TraceTransaction(tm.quorumClient, tx.Hash)
 	if err != nil {
 		return nil, err
 	}
-	if traceResp["calls"] != nil {
-		respCalls := traceResp["calls"].([]interface{})
-		tx.InternalCalls = make([]*types.InternalCall, len(respCalls))
-		for i, respCall := range respCalls {
-			respCallMap := respCall.(map[string]interface{})
-			gas, err := strconv.ParseUint(respCallMap["gas"].(string), 0, 64)
-			if err != nil {
-				return nil, err
-			}
-			gasUsed, err := strconv.ParseUint(respCallMap["gasUsed"].(string), 0, 64)
-			if err != nil {
-				return nil, err
-			}
-			value := uint64(0)
-			if val, ok := respCallMap["value"].(string); ok {
-				value, err = strconv.ParseUint(val, 0, 64)
-				if err != nil {
-					return nil, err
-				}
-			}
-			tx.InternalCalls[i] = &types.InternalCall{
-				From:    types.NewAddress(respCallMap["from"].(string)),
-				To:      types.NewAddress(respCallMap["to"].(string)),
-				Gas:     gas,
-				GasUsed: gasUsed,
-				Value:   value,
-				Input:   types.NewHexData(respCallMap["input"].(string)),
-				Output:  types.NewHexData(respCallMap["output"].(string)),
-				Type:    respCallMap["type"].(string),
-			}
+
+	tx.InternalCalls = make([]*types.InternalCall, len(traceResp.Calls))
+	for i, respCall := range traceResp.Calls {
+		tx.InternalCalls[i] = &types.InternalCall{
+			From:    respCall.From,
+			To:      respCall.To,
+			Gas:     respCall.Gas.ToUint64(),
+			GasUsed: respCall.GasUsed.ToUint64(),
+			Value:   respCall.Value.ToUint64(),
+			Input:   respCall.Input,
+			Output:  respCall.Output,
+			Type:    respCall.Type,
 		}
 	}
 	return tx, nil

--- a/core/monitor/transaction_test.go
+++ b/core/monitor/transaction_test.go
@@ -9,34 +9,32 @@ import (
 	"quorumengineering/quorum-report/types"
 )
 
-var (
-	graphqlResp = map[string]interface{}{
-		"hash":              "0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8",
-		"status":            "0x1",
-		"block":             map[string]interface{}{"number": "0x2", "timestamp": "0x1000"},
-		"index":             0,
-		"nonce":             "0x1",
-		"from":              map[string]interface{}{"address": "0xed9d02e382b34818e88b88a309c7fe71e65f419d"},
-		"to":                nil,
-		"value":             "0x0",
-		"gasPrice":          "0x0",
-		"gas":               "0x47b760",
-		"gasUsed":           "0x280a7",
-		"cumulativeGasUsed": "0x280a7",
-		"createdContract":   map[string]interface{}{"address": "0x1349f3e1b8d71effb47b840594ff27da7e603d17"},
-		"inputData":         "0x608060405234801561001057600080fd5b506040516020806101a18339810180604052602081101561003057600080fd5b81019080805190602001909291905050508060008190555050610149806100586000396000f3fe608060405234801561001057600080fd5b506004361061005e576000357c0100000000000000000000000000000000000000000000000000000000900480632a1afcd91461006357806360fe47b1146100815780636d4ce63c146100af575b600080fd5b61006b6100cd565b6040518082815260200191505060405180910390f35b6100ad6004803603602081101561009757600080fd5b81019080803590602001909291905050506100d3565b005b6100b7610114565b6040518082815260200191505060405180910390f35b60005481565b806000819055507fefe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36816040518082815260200191505060405180910390a150565b6000805490509056fea165627a7a7230582061f6956b053dbf99873b363ab3ba7bca70853ba5efbaff898cd840d71c54fc1d0029000000000000000000000000000000000000000000000000000000000000002a",
-		"privateInputData":  "0x",
-		"isPrivate":         false,
-		"logs": []map[string]interface{}{
-			{
-				"index":   0,
-				"account": map[string]interface{}{"address": "0x1349f3e1b8d71effb47b840594ff27da7e603d17"},
-				"topics":  []string{"0xefe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36"},
-				"data":    "0x0000000000000000000000000000000000000000000000000000000000000042",
-			},
+var graphqlResp = map[string]interface{}{
+	"hash":              "0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8",
+	"status":            "0x1",
+	"block":             map[string]interface{}{"number": "0x2", "timestamp": "0x1000"},
+	"index":             0,
+	"nonce":             "0x1",
+	"from":              map[string]interface{}{"address": "0xed9d02e382b34818e88b88a309c7fe71e65f419d"},
+	"to":                nil,
+	"value":             "0x0",
+	"gasPrice":          "0x0",
+	"gas":               "0x47b760",
+	"gasUsed":           "0x280a7",
+	"cumulativeGasUsed": "0x280a7",
+	"createdContract":   map[string]interface{}{"address": "0x1349f3e1b8d71effb47b840594ff27da7e603d17"},
+	"inputData":         "0x608060405234801561001057600080fd5b506040516020806101a18339810180604052602081101561003057600080fd5b81019080805190602001909291905050508060008190555050610149806100586000396000f3fe608060405234801561001057600080fd5b506004361061005e576000357c0100000000000000000000000000000000000000000000000000000000900480632a1afcd91461006357806360fe47b1146100815780636d4ce63c146100af575b600080fd5b61006b6100cd565b6040518082815260200191505060405180910390f35b6100ad6004803603602081101561009757600080fd5b81019080803590602001909291905050506100d3565b005b6100b7610114565b6040518082815260200191505060405180910390f35b60005481565b806000819055507fefe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36816040518082815260200191505060405180910390a150565b6000805490509056fea165627a7a7230582061f6956b053dbf99873b363ab3ba7bca70853ba5efbaff898cd840d71c54fc1d0029000000000000000000000000000000000000000000000000000000000000002a",
+	"privateInputData":  "0x",
+	"isPrivate":         false,
+	"logs": []map[string]interface{}{
+		{
+			"index":   0,
+			"account": map[string]interface{}{"address": "0x1349f3e1b8d71effb47b840594ff27da7e603d17"},
+			"topics":  []string{"0xefe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36"},
+			"data":    "0x0000000000000000000000000000000000000000000000000000000000000042",
 		},
-	}
-)
+	},
+}
 
 func TestCreateTransaction(t *testing.T) {
 	testBlock := &types.Block{
@@ -49,21 +47,22 @@ func TestCreateTransaction(t *testing.T) {
 		},
 	}
 	mockRPC := map[string]interface{}{
-		"debug_traceTransaction0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8<*client.TraceConfig Value>": map[string]interface{}{
-			"calls": []interface{}{
-				map[string]interface{}{
-					"from":    "0x9d13c6d3afe1721beef56b55d303b09e021e27ab",
-					"gas":     "0x279e",
-					"gasUsed": "0x18aa",
-					"input":   "0x60fe47b10000000000000000000000000000000000000000000000000000000000000042",
-					"output":  "0x",
-					"to":      "0x1932c48b2bf8102ba33b4a6b545c32236e342f34",
-					"type":    "CALL",
-					"value":   "0x0",
+		"debug_traceTransaction0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8<*client.TraceConfig Value>": types.RawOuterCall{
+			Calls: []types.RawInnerCall{
+				{
+					From:    "9d13c6d3afe1721beef56b55d303b09e021e27ab",
+					Gas:     types.HexNumber(10142),
+					GasUsed: types.HexNumber(6314),
+					Input:   "60fe47b10000000000000000000000000000000000000000000000000000000000000042",
+					Output:  "",
+					To:      "1932c48b2bf8102ba33b4a6b545c32236e342f34",
+					Type:    "CALL",
+					Value:   types.HexNumber(0),
 				},
 			},
 		},
 	}
+
 	tm := NewDefaultTransactionMonitor(client.NewStubQuorumClient(mockGraphQL, mockRPC))
 	tx, err := tm.fetchTransaction(testBlock, types.NewHash("0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8"))
 	assert.Nil(t, err)
@@ -89,17 +88,17 @@ func TestTransactionMonitor_PullTransactions(t *testing.T) {
 		},
 	}
 	mockRPC := map[string]interface{}{
-		"debug_traceTransaction0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8<*client.TraceConfig Value>": map[string]interface{}{
-			"calls": []interface{}{
-				map[string]interface{}{
-					"from":    "0x9d13c6d3afe1721beef56b55d303b09e021e27ab",
-					"gas":     "0x279e",
-					"gasUsed": "0x18aa",
-					"input":   "0x60fe47b10000000000000000000000000000000000000000000000000000000000000042",
-					"output":  "0x",
-					"to":      "0x1932c48b2bf8102ba33b4a6b545c32236e342f34",
-					"type":    "CALL",
-					"value":   "0x0",
+		"debug_traceTransaction0xe625ba9f14eed0671508966080fb01374d0a3a16b9cee545a324179b75f30aa8<*client.TraceConfig Value>": types.RawOuterCall{
+			Calls: []types.RawInnerCall{
+				{
+					From:    "9d13c6d3afe1721beef56b55d303b09e021e27ab",
+					Gas:     types.HexNumber(10142),
+					GasUsed: types.HexNumber(6314),
+					Input:   "60fe47b10000000000000000000000000000000000000000000000000000000000000042",
+					Output:  "",
+					To:      "1932c48b2bf8102ba33b4a6b545c32236e342f34",
+					Type:    "CALL",
+					Value:   types.HexNumber(0),
 				},
 			},
 		},

--- a/types/types.go
+++ b/types/types.go
@@ -26,6 +26,21 @@ type RawBlock struct {
 	Transactions []Hash    `json:"transactions"`
 }
 
+type RawInnerCall struct {
+	Type    string
+	To      Address
+	Input   HexData
+	From    Address
+	Value   HexNumber
+	Gas     HexNumber
+	GasUsed HexNumber
+	Output  HexData
+}
+
+type RawOuterCall struct {
+	Calls []RawInnerCall
+}
+
 type Block struct {
 	Hash         Hash   `json:"hash"`
 	ParentHash   Hash   `json:"parentHash"`


### PR DESCRIPTION
Use concrete type to unmarshall to when tracing transactions,
This makes it easiest to handle in the main application, instead of doing unsafe type conversions and manual handling of values.