### PR TITLE
GraphQL notes - vhosts note & extra logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ over its lifetime. It will also interpret and parse events that the contract emi
     - Quorum must be a version that supports the dump accounts API method, which is currently merged but unreleased. Build Quorum from the master branch to get this feature.
     - Quorum needs to be run with GraphQL and websockets open, with `eth`, `admin` and `debug` RPC APIs available.
     - Quorum Reporting fetches a lot of historic data that is pruned by Quorum under default `full` gcmode. It is recommended to run Quorum in `archive` mode.
+    - If connecting using a hostname, make sure Geth is started with the correct `graphql.vhosts` attribute suitable to your environment. For testing, `--graphql.vhosts '*'` is sufficient.
     
     e.g. `geth --graphql --graphql.vhosts=* --ws --wsport 23000 --wsapi admin,eth,debug --wsorigins=* --gcmode=archive ...`
 

--- a/client/quorum.go
+++ b/client/quorum.go
@@ -41,6 +41,7 @@ func NewQuorumClient(rawUrl, qgUrl string) (*QuorumClient, error) {
 	log.Debug("Connecting to GraphQL endpoint", "url", qgUrl)
 	var resp map[string]interface{}
 	if err := quorumClient.ExecuteGraphQLQuery(&resp, CurrentBlockQuery()); err != nil || len(resp) == 0 {
+		log.Error("Error calling GraphQL endpoint at startup", "err", err)
 		return nil, errors.New("call graphql endpoint failed")
 	}
 	log.Debug("Connected to GraphQL endpoint")


### PR DESCRIPTION
Add error log showing the error found when failing to connect to GraphQL. Note the error can still sometimes be uninformative.

Include `vhosts` usage for Quorum in the case the user is using hostnames.