### PR TITLE
Fixing release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,17 @@ jobs:
           fi
           echo "::set-output name=target::$target"
           echo "::set-output name=repo::$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+      - name: 'Define image tag'
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            target="latest"
+          else
+            REF=${{ github.ref }}
+            target=$(echo $REF | sed 's/refs\/tags\/v//g')
+          fi
+          echo "::set-output name=VERSION::$target"
       - name: 'Build and push to Github Packages'
         if: steps.setup.outputs.target == 'Github Packages'
         uses: docker/build-push-action@v1
@@ -30,7 +41,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           repository: ${{ steps.setup.outputs.repo }}/acctests
-          tag_with_ref: true
+          tags: ${{ steps.tag.outputs.VERSION }}
           add_git_labels: true
       - name: 'Build and push to Docker Hub'
         if: steps.setup.outputs.target == 'Docker Hub'
@@ -39,7 +50,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tag_with_ref: true
+          tags: ${{ steps.tag.outputs.VERSION }}
           add_git_labels: true
       - name: 'Notify'
         if: always()


### PR DESCRIPTION
PR fixes release tag for docker images from to remove the leading `v`. Changes release tag from `vA.B.C` to `A.B.C`