### PR TITLE
Store incremental state changes only and some minor improvements

### DIFF
--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -79,7 +79,7 @@ func TestDumpAddress_WithError(t *testing.T) {
 	mockRPC := map[string]interface{}{}
 	stubClient := NewStubQuorumClient(nil, mockRPC)
 
-	dump, err := DumpAddress(stubClient, types.NewAddress("0x1349f3e1b8d71effb47b840594ff27da7e603d17"), 1)
+	dump, err := DumpAddress(stubClient, types.NewAddress("0x1349f3e1b8d71effb47b840594ff27da7e603d17"), 0, 1, false)
 	assert.EqualError(t, err, "not found")
 	assert.Nil(t, dump)
 }
@@ -93,7 +93,7 @@ func TestDumpAddress(t *testing.T) {
 	}
 	stubClient := NewStubQuorumClient(nil, mockRPC)
 
-	dump, err := DumpAddress(stubClient, types.NewAddress("0x1349f3e1b8d71effb47b840594ff27da7e603d17"), 1)
+	dump, err := DumpAddress(stubClient, types.NewAddress("0x1349f3e1b8d71effb47b840594ff27da7e603d17"), 0, 1, false)
 	assert.Nil(t, err)
 	assert.EqualValues(t, &types.AccountState{
 		Root:    types.NewHash("0xefe5cb8d23d632b5d2cdd9f0a151c4b1a84ccb7afa1c57331009aa922d5e4f36"),

--- a/client/ws.go
+++ b/client/ws.go
@@ -117,11 +117,11 @@ func (c *webSocketClient) subscribeChainHead(ch chan<- types.RawHeader) error {
 }
 
 // send rpc call
-func (c *webSocketClient) sendRPCMsg(ch chan<- *message, method string, args ...interface{}) error {
+func (c *webSocketClient) sendRPCMsg(ch chan<- *message, method string, args ...interface{}) (error, string) {
 	c.connMux.Lock()
 	defer c.connMux.Unlock()
 	if c.conn == nil {
-		return errors.New("no WebSocket connection")
+		return errors.New("no WebSocket connection"), ""
 	}
 
 	msg := &message{
@@ -133,7 +133,7 @@ func (c *webSocketClient) sendRPCMsg(ch chan<- *message, method string, args ...
 	if args != nil {
 		params, err := json.Marshal(args)
 		if err != nil {
-			return err
+			return err, msg.ID
 		}
 		msg.Params = params
 	}
@@ -146,9 +146,9 @@ func (c *webSocketClient) sendRPCMsg(ch chan<- *message, method string, args ...
 
 	if err := c.conn.WriteJSON(msg); err != nil {
 		log.Error("Write JSON RPC message error", "error", err, "msg", msg)
-		return err
+		return err, msg.ID
 	}
-	return nil
+	return nil, msg.ID
 }
 
 // listen and handle message

--- a/core/filter/service.go
+++ b/core/filter/service.go
@@ -72,12 +72,13 @@ func (fs *FilterService) Start() error {
 					log.Warn("Fetching last persisted block number failed", "err", err)
 					continue
 				}
-				log.Debug("Last persisted block number found", "block number", current)
+				log.Debug("FilterService - Last persisted block number found", "block number", current)
 				lastFilteredAll, lastFiltered, err := fs.getLastFiltered(current)
 				if err != nil {
 					log.Warn("Fetching last filtered failed", "err", err)
 					continue
 				}
+				log.Debug("FilterService - check Indexing for registered addresses", "current", current, "lastFiltered", lastFiltered)
 				for current > lastFiltered {
 					//check if we are shutting down before next round
 					select {

--- a/core/filter/storage.go
+++ b/core/filter/storage.go
@@ -87,15 +87,18 @@ func (sf *StorageFilter) StateFetchWorker() {
 
 				log.Debug("Fetching contract storage", "block number", blockToPull.BlockNumber)
 				for _, address := range blockToPull.Addresses {
-					if lastFiltered, err := sf.db.GetLastFiltered(address); err != nil {
-						log.Error("getLastFiltered failed", "address", address, "err", err)
-					} else {
-						if lastFiltered > 0 {
-							lastFilteredMap[address] = true
+					if _, lastFilteredFound := lastFilteredMap[address]; !lastFilteredFound {
+						if lastFiltered, err := sf.db.GetLastFiltered(address); err != nil {
+							log.Error("getLastFiltered failed", "address", address, "err", err)
 						} else {
-							lastFilteredMap[address] = false
+							if lastFiltered > 0 {
+								lastFilteredMap[address] = true
+							} else {
+								lastFilteredMap[address] = false
+							}
 						}
 					}
+
 					changed, err := sf.didStorageRootChange(address, blockToPull.BlockNumber)
 					for err != nil {
 						changed, err = sf.didStorageRootChange(address, blockToPull.BlockNumber)

--- a/core/filter/storage.go
+++ b/core/filter/storage.go
@@ -87,8 +87,7 @@ func (sf *StorageFilter) StateFetchWorker() {
 
 				log.Debug("Fetching contract storage", "block number", blockToPull.BlockNumber)
 				for _, address := range blockToPull.Addresses {
-					found, filtered := lastFilteredMap[address]
-					if !found || !filtered {
+					if found, filtered := lastFilteredMap[address]; !found || !filtered {
 						if lastFiltered, err := sf.db.GetLastFiltered(address); err != nil {
 							log.Error("getLastFiltered failed", "address", address, "err", err)
 						} else {

--- a/core/filter/storage.go
+++ b/core/filter/storage.go
@@ -87,7 +87,8 @@ func (sf *StorageFilter) StateFetchWorker() {
 
 				log.Debug("Fetching contract storage", "block number", blockToPull.BlockNumber)
 				for _, address := range blockToPull.Addresses {
-					if _, lastFilteredFound := lastFilteredMap[address]; !lastFilteredFound {
+					found, filtered := lastFilteredMap[address]
+					if !found || !filtered {
 						if lastFiltered, err := sf.db.GetLastFiltered(address); err != nil {
 							log.Error("getLastFiltered failed", "address", address, "err", err)
 						} else {

--- a/core/monitor/service.go
+++ b/core/monitor/service.go
@@ -109,6 +109,7 @@ func (m *MonitorService) startWorker(stopChan <-chan struct{}) {
 		select {
 		case block := <-m.newBlockChan:
 			// Listen to new block channel and process if new block comes.
+			log.Debug("worker - new block received", "number", block.Number)
 			err := m.processBlock(block)
 			for err != nil {
 				log.Warn("Error processing block", "block number", block.Number, "err", err)


### PR DESCRIPTION
This PR contains the following changes:

- Store the incremental state changes of a contract only instead of storing full state dump for every block.
- Change default timeout for getModifiedState and dumpAddress to 5minutes
- Enhance RPC call debug message to display msg.id